### PR TITLE
Fix Kivai packaging metadata to TOIL and add Product ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,5 +212,6 @@ is maintained in the Tech4Life products repository:
 
 https://github.com/tech4life-beyond/products/tree/main/kivai
 
-This repository contains the technical implementation layer of the Kivai Platform.
+Product ID: T4L-TOIL-002-KIVAI
 
+This repository contains the technical implementation layer of the Kivai Platform.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ setup(
     name="kivai_sdk",
     version="0.1.3",
     description="SDK for validating Kivai protocol commands",
-    author="OpenKivai Community",
+    author="Tech4Life & Beyond LLC",
+    license="Tech4Life Open Impact License (TOIL) v1.0",
     packages=find_packages(),
     package_data={
         'kivai_sdk': ['schema/kivai-command.schema.json'],
@@ -13,7 +14,6 @@ setup(
     keywords=["kivai", "validator", "jsonschema", "iot", "commands"],
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License"
+        "License :: Other/Proprietary License"
     ],
 )
-


### PR DESCRIPTION
### Motivation
- Align packaging metadata with the Tech4Life Open Impact License (TOIL) v1.0 and attribute the project to Tech4Life & Beyond LLC instead of the OpenKivai Community.
- Ensure product identity is explicit in documentation by adding a Product ID for registry/product-pack references.
- Preserve code behavior and retain legacy schema files while avoiding changes to intent specs or API docs.

### Description
- Update `setup.py` to set `author` to "Tech4Life & Beyond LLC", add `license` = "Tech4Life Open Impact License (TOIL) v1.0", and change the license classifier to `License :: Other/Proprietary License`.
- Add `Product ID: T4L-TOIL-002-KIVAI` to the README in the "Official TOIL Product Pack" section.
- No functional code changes were made and no legacy schema files or intent/API docs were modified.
- Checklist: Packaging metadata aligned with TOIL v1.0; Product ID added; intent specs/API docs untouched.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f37dd908832db0637b78b22330ae)