### PR TITLE
Align docs to Kivai Intent Schema v1.0 contract

### DIFF
--- a/KIVAI_V1_PLATFORM_SCOPE.md
+++ b/KIVAI_V1_PLATFORM_SCOPE.md
@@ -38,9 +38,9 @@ Kivai v1.0 assumes a **Gateway/Hub** (phone, home hub, router, edge device) as t
 - Standard request/response patterns
 - Standardized status lifecycle:
   - acknowledged
-  - executing
   - success
   - failed (with reason codes)
+  - (Internal implementations may track intermediate states like "executing," but these are not part of the public v1.0 status contract.)
 
 ### 3.3 Gateway/Hub Orchestration Model (Default)
 - Gateway receives user request (voice/text)
@@ -94,7 +94,7 @@ Gateway produces:
 - auth proof required (owner role)
 
 Device returns:
-- acknowledged → executing → success/failed
+- acknowledged → success/failed
 
 ---
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -2,7 +2,7 @@
 
 ## Maintainers
 
-The Kivai Protocol is currently maintained by [@ArielMartin-Tech4Life](https://github.com/ArielMartin-Tech4Life).
+The Kivai Platform is currently maintained by [@ArielMartin-Tech4Life](https://github.com/ArielMartin-Tech4Life).
 
 Want to help?  
 We’re looking for contributors — [join us!](mailto:tech4lifeandbeyond@gmail.com)
@@ -20,7 +20,7 @@ Decisions are made by:
 
 ## Contributions
 
-Contributors help shape the future of the protocol. You can:
+Contributors help shape the future of the platform. You can:
 
 - Propose changes to the spec
 - Suggest or improve schemas

--- a/docs/context-sharing.md
+++ b/docs/context-sharing.md
@@ -1,6 +1,6 @@
 # Kivai Context Sharing
 
-Kivai supports smart context sharing between devices to create seamless, multi-device interactions.
+Kivai supports smart context sharing between devices to create seamless, multi-device interactions on the Kivai Platform.
 
 ---
 
@@ -10,7 +10,7 @@ Kivai supports smart context sharing between devices to create seamless, multi-d
 
 - Location (`kitchen`, `living room`)
 - Time (`now`, `later`, `at 6pm`)
-- Active intent (e.g. `"command": "turn off"`)
+- Active intent context (e.g. `intent` + `target` + `meta`)
 - User identity and preferences
 - Device capabilities
 
@@ -33,9 +33,16 @@ Context is shared as a JSON object like this:
 ```json
 {
   "intent": {
-    "command": "turn off",
-    "object": "light",
-    "location": "bedroom"
+    "intent": "turn_off",
+    "target": {
+      "capability": "light_control",
+      "zone": "bedroom"
+    },
+    "meta": {
+      "timestamp": "2025-04-17T17:20:00Z",
+      "language": "en",
+      "source": "gateway"
+    }
   },
   "user": {
     "id": "abc123",
@@ -72,3 +79,9 @@ Context is shared as a JSON object like this:
 
 Let’s build an ecosystem where devices cooperate — not compete.  
 Context is the bridge to intelligence.
+
+---
+
+## Compatibility / Legacy Notes
+
+Legacy (pre-v1.0) context-sharing examples used `command`, `object`, and `location`. v1.0 context exchanges should mirror the Intent API fields (`intent`, `target`, `meta`).

--- a/docs/intent-api.md
+++ b/docs/intent-api.md
@@ -1,6 +1,6 @@
 # Kivai Intent API
 
-The Intent API defines how devices and services should handle structured Kivai commands.
+The Intent API defines how devices and services should handle structured Kivai intents on the Kivai Platform.
 
 It acts as the bridge between natural language and real-world action.
 
@@ -8,17 +8,26 @@ It acts as the bridge between natural language and real-world action.
 
 ## 🔁 Request Format
 
-The device or service receives a JSON payload like:
+The device or service receives a v1.0 intent payload like:
 
 ```json
 {
-  "command": "turn on",
-  "object": "light",
-  "location": "kitchen",
-  "trigger": "Kivai",
-  "confidence": 0.95,
-  "language": "en",
-  "user_id": "abc123"
+  "intent_id": "c9c4c8d1-2d6f-4d6c-9a2f-1f2c3a4b5c6d",
+  "intent": "turn_on",
+  "target": {
+    "capability": "light_control",
+    "zone": "kitchen"
+  },
+  "params": {
+    "level": 100
+  },
+  "meta": {
+    "timestamp": "2026-02-06T21:10:00Z",
+    "language": "en",
+    "confidence": 0.97,
+    "source": "gateway",
+    "trigger": "Kivai"
+  }
 }
 ```
 
@@ -29,30 +38,38 @@ The device or service receives a JSON payload like:
 When a device receives a request, it should:
 
 1. **Parse** the payload  
-2. **Match** it to known capabilities or device actions  
-3. **Execute** the requested command  
+2. **Validate + authorize** per device capability and security rules  
+3. **Execute** the requested intent  
 4. **Respond** with a status update  
 
 ---
 
 ## 🔁 Response Format
 
-Devices that receive a Kivai command should respond using a standard format like this:
+Devices that receive a Kivai intent should respond using a standard format like this:
 
 ```json
 {
+  "intent_id": "c9c4c8d1-2d6f-4d6c-9a2f-1f2c3a4b5c6d",
   "status": "success",
-  "message": "Light turned on",
-  "timestamp": "2025-04-17T14:23:00Z",
-  "device_id": "kitchen-light-01"
+  "device_id": "kitchen-light-01",
+  "timestamp": "2026-02-06T21:10:01Z"
 }
 ```
 
 ### ✅ Required fields:
 
-- **status**: `"success"` or `"error"`  
-- **message**: Human-readable result  
+- **intent_id**: ID of the intent being acknowledged or completed  
+- **status**: `acknowledged` | `success` | `failed`  
+- **device_id**: Unique device identifier  
 - **timestamp**: When the response was generated (ISO 8601 format)  
-- **device_id** *(optional)*: Unique device identifier  
+
+On failure, include an `error` object with a code and message.
 
 This format ensures consistency across devices and services, and makes debugging easier.
+
+---
+
+## Compatibility / Legacy Notes
+
+Pre-v1.0 drafts used `command`, `object`, and `location` fields for requests. The v1.0 Intent API standardizes on `intent`, `target`, and `meta`.

--- a/docs/legacy/CORE_LEGACY.md
+++ b/docs/legacy/CORE_LEGACY.md
@@ -1,5 +1,7 @@
 # kivai-core
 
+> Legacy terminology note: this document uses "Kivai Protocol" as historical language for what is now the Kivai Platform.
+
 The core logic, libraries, and reference implementation of the **Kivai Protocol** — an open, universal way to communicate with intelligent devices in natural language.
 
 ---

--- a/docs/legacy/LANGUAGE_LEGACY.md
+++ b/docs/legacy/LANGUAGE_LEGACY.md
@@ -1,6 +1,8 @@
 # kivai-language
 The official grammar and syntax of the Kivai language for intelligent device interaction.
 
+> Legacy terminology note: references to "protocol" or legacy command formats in this document predate the Kivai Platform naming and v1.0 intent schema.
+
 # Kivai Language Reference
 
 Kivai is a simple, universal, human-readable language designed for communicating with intelligent devices — naturally and efficiently.

--- a/docs/legacy/MANIFESTO_LEGACY.md
+++ b/docs/legacy/MANIFESTO_LEGACY.md
@@ -1,5 +1,7 @@
 # Kivai Manifesto
 
+> Legacy terminology note: references to "protocol" in this document predate the Kivai Platform naming.
+
 The open-source vision for Kivai — a universal language for communicating with intelligent devices.
 
 🌍 **What is Kivai?**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,4 @@
-# Kivai Protocol Roadmap
+# Kivai Platform Roadmap
 
 ## Phase 1: Initial Setup
 - Set up mock device handlers (mock-thermostat, mock-light, etc.)
@@ -9,7 +9,7 @@
 - Label issues with **good first issue** for easier onboarding
 - Add documentation for project setup and usage
 - Promote the project for visibility and attract initial contributors
-- Provide a simple demo or CLI script to show how Kivai Protocol works
+- Provide a simple demo or CLI script to show how the Kivai Platform works
 
 ## Phase 3: Developer Experience
 - Create SDKs for Kivai commands (Python/JS)
@@ -19,6 +19,6 @@
 
 ## Phase 4: Community Building
 - Engage with contributors, maintainers, and developers
-- Add more mock devices and use cases to expand the protocol
+- Add more mock devices and use cases to expand the platform
 - Encourage collaboration on new features and improvements
 - Establish a community-driven roadmap with ongoing feedback and contributions


### PR DESCRIPTION
### Motivation

- Ensure all public documentation reflects the canonical v1.0 intent model using `intent`, `target`, and `meta` and the v1.0 lifecycle statuses (`acknowledged` | `success` | `failed`).
- Remove accidental or public-facing references to legacy request examples and to intermediate lifecycle states, and normalize naming to "Kivai Platform" while preserving historical notes.

### Description

- Updated Intent API examples and response format to the v1.0 intent payload (`intent_id`, `intent`, `target`, `params`, `meta`) and the v1.0 status set (`acknowledged` | `success` | `failed`), and added a compatibility note for legacy fields. 
- Rewrote context-sharing examples to use the v1.0 model (`intent` / `target` / `meta`) and added a dedicated compatibility/legacy note preserving pre-v1.0 examples as historical reference. 
- Removed the public-facing `executing` lifecycle state from the v1.0 platform scope and clarified it may exist only as an internal implementation detail; normalized references from "Kivai Protocol" to "Kivai Platform" and added legacy terminology notes in archived docs. 

Updated files checklist:
- [x] `KIVAI_V1_PLATFORM_SCOPE.md`
- [x] `docs/intent-api.md`
- [x] `docs/context-sharing.md`
- [x] `docs/GOVERNANCE.md`
- [x] `docs/roadmap.md`
- [x] `docs/legacy/CORE_LEGACY.md`
- [x] `docs/legacy/LANGUAGE_LEGACY.md`
- [x] `docs/legacy/MANIFESTO_LEGACY.md`

### Testing

- Documentation-only changes; no automated tests were required or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f5bc7f48832d8e58bc0cdcb39300)