### PR TITLE
feat: introduce policy engine and role model

### DIFF
--- a/kivai_sdk/security/__init__.py
+++ b/kivai_sdk/security/__init__.py
@@ -1,0 +1,1 @@
+from .policy import evaluate_authorization, required_role_for_intent

--- a/kivai_sdk/security/__init__.py
+++ b/kivai_sdk/security/__init__.py
@@ -1,1 +1,9 @@
-from .policy import evaluate_authorization, required_role_for_intent
+from .policy import (
+    evaluate_authorization as evaluate_authorization,
+    required_role_for_intent as required_role_for_intent,
+)
+
+__all__ = [
+    "evaluate_authorization",
+    "required_role_for_intent",
+]

--- a/kivai_sdk/security/policy.py
+++ b/kivai_sdk/security/policy.py
@@ -1,0 +1,58 @@
+"""
+Policy Engine (v0.6)
+
+Responsible for:
+- Determining if an intent requires authorization
+- Validating auth proof presence and role alignment
+- Returning deterministic decision
+
+Does NOT:
+- Validate schema
+- Execute adapters
+- Perform routing
+"""
+
+from typing import Optional, Tuple
+
+from kivai_sdk.security.roles import Role
+
+
+# Baseline intent → required role mapping
+_INTENT_ROLE_POLICY: dict[str, Role] = {
+    "unlock_door": "owner",
+    # extend here in future versions
+}
+
+
+def required_role_for_intent(intent: str) -> Optional[Role]:
+    return _INTENT_ROLE_POLICY.get(intent)
+
+
+def evaluate_authorization(payload: dict) -> Tuple[bool, Optional[str]]:
+    """
+    Returns:
+        (authorized: bool, error_code: Optional[str])
+    """
+    intent = payload.get("intent")
+    required_role = required_role_for_intent(intent)
+
+    # If no role required → always allowed
+    if required_role is None:
+        return True, None
+
+    auth = payload.get("auth")
+
+    if not isinstance(auth, dict):
+        return False, "AUTH_REQUIRED"
+
+    token = auth.get("token")
+    role = auth.get("required_role")
+
+    if not isinstance(token, str) or not token.strip():
+        return False, "AUTH_REQUIRED"
+
+    if role != required_role:
+        return False, "AUTH_FORBIDDEN"
+
+    # v0.6 baseline does not verify token cryptographically yet
+    return True, None

--- a/kivai_sdk/security/roles.py
+++ b/kivai_sdk/security/roles.py
@@ -1,0 +1,21 @@
+"""
+Role model for Kivai security layer (v0.6).
+
+This defines canonical roles for authorization evaluation.
+Extensible in future versions.
+"""
+
+from typing import Literal
+
+# Canonical roles (v0.6 baseline)
+Role = Literal[
+    "owner",
+    "admin",
+    "user",
+    "service",
+]
+
+# Future:
+# - hierarchical roles
+# - role inheritance
+# - dynamic policy backends

--- a/tests/test_runtime_v01.py
+++ b/tests/test_runtime_v01.py
@@ -44,9 +44,9 @@ class TestRuntimeV01(unittest.TestCase):
 
     def test_auth_required_without_token(self):
         payload = canonical_payload(
-            "echo",
-            target={"capability": "speaker", "zone": "living_room"},
-            params={"message": "secure"},
+            "unlock_door",
+            target={"device_id": "door-front-01"},
+            params={},
             auth={"required_role": "owner", "token": ""},
         )
         ack = execute_intent(payload)


### PR DESCRIPTION
Adds security policy engine under kivai_sdk/security. Moves intent authorization logic out of runtime into centralized policy evaluation. Removes hardcoded unlock_door baseline logic.
Establishes foundation for scalable role-based access control.