### PR TITLE
chore: kivai IPO baseline + CI supply-chain hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto eol=lf
+
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.txt text eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.pdf binary
+*.zip binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @tech4life-beyond/owners @tech4life-beyond/architects
+/schema/ @tech4life-beyond/owners @tech4life-beyond/architects
+/kivai_sdk/ @tech4life-beyond/owners @tech4life-beyond/architects
+/tests/ @tech4life-beyond/owners @tech4life-beyond/architects

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+What does this PR change?
+
+## Type
+- [ ] Schema / Spec
+- [ ] Validator / Runtime
+- [ ] Gateway / Adapters
+- [ ] Tests
+- [ ] CI / Workflows
+- [ ] Docs
+
+## Checklist
+- [ ] Actions pinned by SHA (if workflow changes)
+- [ ] Tests updated/added (if behavior changes)
+- [ ] Schema changes are backwards-compatible or clearly versioned
+- [ ] No confidential/internal-only content added

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: kivai-python-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -29,7 +36,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .
-          pip install ruff
+          pip install "ruff==0.15.1"
 
       - name: Lint
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.DS_Store
+Thumbs.db
+
+__pycache__/
+*.py[cod]
+
+.venv/
+venv/
+.env
+
+*.log
+
+dist/
+build/
+*.egg-info/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+Tech4Life & Beyond is committed to a respectful, inclusive, and safe environment.
+
+Be kind. Be constructive. Assume good intent.
+Harassment, discrimination, or abusive behavior is not tolerated.
+
+For enforcement, contact the organization Owners.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support
+
+This repository contains KIVAI (schema-first intent validation + gateway runtime).
+
+## What we support here
+- KIVAI intent schema and related specifications (`schema/`, `KIVAI_INTENT_SCHEMA_V1_SPEC.md`)
+- SDK runtime and validator (`kivai_sdk/`)
+- Gateway (FastAPI) entrypoint (`kivai_sdk/gateway.py` and `kivai serve`)
+- Mock devices and adapters used for development (`mock-devices/`)
+- CI behavior and tests (`tests/`)
+
+## How to get help
+Open a GitHub Issue with:
+- A clear title
+- Steps to reproduce
+- The exact command used and full error output
+- Relevant file paths (avoid pasting secrets)
+
+## Confidentiality
+Do not include:
+- internal royalty splits
+- partner/manufacturer terms
+- private legal/finance information
+
+If sensitive, contact Owners/Architects privately.
+
+## Maintainers
+Changes to schema, gateway behavior, or execution runtime require CODEOWNERS review.


### PR DESCRIPTION
Pins GitHub Actions by commit SHA and adds minimal workflow permissions + concurrency.

Pins ruff for reproducible linting.

Adds missing governance baseline files (CODE_OF_CONDUCT, SUPPORT, CODEOWNERS, PR template, git hygiene).