### PR TITLE
Make KIVAI demo-ready: fix packaging schema, add mock adapter, add sy…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,33 @@
 # KIVAI
 
-## K.I.V.A.I.
-**Knowledge Interface & Validation Architecture for Interoperability**
+## Knowledge Interface & Validation Architecture for Interoperability
 
-KIVAI is an open interoperability platform that standardizes how AI systems interact with physical and digital devices.
+KIVAI is an open interoperability infrastructure that standardizes how AI systems, software applications, and physical devices exchange and execute actionable intents.
 
-It provides a deterministic, auditable, and vendor-neutral execution layer between AI-generated intents and real-world device actions.
+KIVAI provides a deterministic, auditable, and vendor‑neutral execution layer between intent generation and real‑world device behavior.
 
-Developed and maintained by **Tech4Life & Beyond LLC**, KIVAI is infrastructure — not a chatbot, not an assistant, and not a SaaS product.
+Developed and maintained by **Tech4Life & Beyond LLC**, KIVAI is infrastructure — not a chatbot, not an assistant, and not a SaaS platform.
 
-AI interprets language.
+AI interprets language.  
 KIVAI standardizes execution.
 
 ---
 
-# Why KIVAI Exists
+# Purpose
 
-Artificial Intelligence can understand natural language.
+Artificial Intelligence can interpret human intent, but physical and digital systems require a structured, reliable execution contract.
 
-However, devices require a reliable and structured execution contract to:
+KIVAI exists to provide:
 
-- Validate intents safely and deterministically  
-- Route commands across different devices and brands  
-- Enforce authentication and authorization policies  
-- Provide auditability and traceability  
-- Avoid ecosystem lock-in  
+- Deterministic intent validation
+- Vendor‑neutral routing across heterogeneous devices
+- Security and authorization enforcement
+- Auditability and traceability
+- Long‑term interoperability independent of vendor ecosystems
 
-Without a shared contract, AI-to-device interaction becomes fragile, unsafe, and vendor-controlled.
+Without a shared execution layer, AI‑device interaction becomes fragmented and unsafe.
 
-KIVAI defines the contract.
+KIVAI defines that execution layer.
 
 ---
 
@@ -36,40 +35,46 @@ KIVAI defines the contract.
 
 KIVAI is:
 
-- An **Intent Standard (canonical schema)**  
-- A **Routing Model (device_id or capability + zone)**  
-- A **Security & Authorization baseline**  
-- An **Adapter execution layer**  
-- An **Audit-capable runtime**  
+- A canonical **Intent Standard**
+- A deterministic **Execution Runtime**
+- A device‑agnostic **Routing Layer**
+- A secure **Authorization Enforcement Layer**
+- An extensible **Adapter Execution Framework**
+- An auditable **Gateway Reference Implementation**
 
 KIVAI is NOT:
 
-- A conversational AI  
-- A device manufacturer  
-- A UI layer  
-- A cloud-only SaaS  
+- A chatbot
+- A voice assistant
+- A device manufacturer
+- A UI platform
+- A cloud SaaS dependency
 
-It is infrastructure designed for long-term interoperability.
-
----
-
-# Platform Architecture (v1.0)
-
-KIVAI v1.0 assumes a **Gateway-Orchestrated Model** by default.
-
-## Execution Flow
-
-1. A user speaks to an AI assistant.
-2. The AI generates a structured KIVAI intent.
-3. A trusted Gateway validates, authenticates, and routes the intent.
-4. A device adapter executes the action.
-5. The runtime returns a deterministic ACK envelope.
-
-Mesh networking between devices is optional and not required in v1.0.
+It is execution infrastructure.
 
 ---
 
-# Canonical Intent Schema (v1.0)
+# Execution Model (Gateway-Orchestrated)
+
+Typical execution flow:
+
+User or Application
+↓
+Intent JSON
+↓
+KIVAI Gateway
+↓
+Adapter
+↓
+Device or System
+↓
+Deterministic ACK Response
+
+KIVAI does not generate intents. It validates, authorizes, routes, and executes them.
+
+---
+
+# Canonical Intent Schema
 
 The official schema is located at:
 
@@ -77,180 +82,166 @@ The official schema is located at:
 schema/kivai-intent-v1.schema.json
 ```
 
-This schema defines the universal KIVAI intent contract.
+This file is the single source of truth for the KIVAI Intent Standard.
 
-## Canonical Example
+Example intent:
 
 ```json
 {
-  "intent_id": "c9c4c8d1-2d6f-4d6c-9a2f-1f2c3a4b5c6d",
-  "intent": "turn_on",
+  "intent_id": "demo-001",
+  "intent": "power.on",
   "target": {
-    "capability": "light_control",
-    "zone": "kitchen"
-  },
-  "params": {
-    "level": 100
+    "device_id": "tv-bedroom"
   },
   "meta": {
-    "timestamp": "2026-02-06T21:10:00Z",
+    "timestamp": "2026-02-20T00:00:00Z",
     "language": "en",
-    "confidence": 0.97,
-    "source": "gateway",
-    "trigger": "Kivai"
+    "confidence": 1.0
   }
 }
 ```
 
 ---
 
-# Targeting Model
+# Gateway Reference Implementation
 
-KIVAI supports two routing strategies:
+The repository includes a reference gateway built with FastAPI.
 
-## 1. Direct Device Targeting (Preferred)
+Endpoints:
 
-```json
-"target": {
-  "device_id": "door-patio-01"
-}
+Health:
+
+```
+GET /health
 ```
 
-## 2. Capability + Zone Targeting (Fallback)
+Validate:
 
-```json
-"target": {
-  "capability": "lock_control",
-  "zone": "patio"
-}
+```
+POST /v1/validate
 ```
 
-At least one of the following MUST be present:
+Execute:
 
-- `device_id`
-- OR (`capability` + `zone`)
+```
+POST /v1/execute
+```
+
+The gateway validates schema compliance, evaluates authorization, routes the intent, and executes it via registered adapters.
 
 ---
 
-# Security Baseline
+# Adapter Architecture
 
-Sensitive intents (locks, payments, alarms, surveillance, safety actuators) require an `auth` object.
+Adapters connect intents to real execution targets.
 
-```json
-"auth": {
-  "required_role": "owner",
-  "token": "signed-session-token"
-}
-```
+Examples:
 
-The runtime MUST:
+- Smart TVs
+- IoT devices (ESP32, Raspberry Pi, sensors)
+- Software services
+- Automation systems
 
-- Reject missing authorization for protected intents  
-- Return deterministic error codes  
-- Never mask authorization failures as schema errors  
+Adapters must:
 
----
+- Declare supported intent
+- Execute deterministically
+- Return structured execution results
 
-# ACK / Execution Envelope
-
-Every execution returns a stable response envelope containing:
-
-- `execution_id` (trace ID)
-- `intent_id`
-- `timestamp`
-- `status` (`ok` | `failed`)
-- `intent`
-- optional `device_id`
-- optional `route`
-- `result` (on success)
-- `error` (on failure)
-
-Example failure:
-
-```json
-{
-  "execution_id": "e5d4...",
-  "intent_id": "c9c4...",
-  "timestamp": "2026-02-06T21:10:01Z",
-  "status": "failed",
-  "intent": "unlock_door",
-  "error": {
-    "code": "AUTH_REQUIRED",
-    "message": "Owner authentication required"
-  }
-}
-```
+Adapters do not perform authorization. Authorization is enforced by the runtime.
 
 ---
 
 # Repository Structure
 
-- `schema/` — Canonical intent schema (v1.0)
-- `docs/` — Architecture and deployment documentation
-- `kivai_sdk/` — Reference runtime & SDK implementation
-- `tests/` — Automated validation suite
-- `mock-devices/` — Local mock devices for integration testing
+```
+schema/
+    kivai-intent-v1.schema.json
+
+kivai_sdk/
+    runtime.py
+    gateway.py
+    adapters/
+
+
+
+deploy/
+    raspberrypi/
+
+
+
+docs/
+
+
+
+tests/
+
+```
+
+---
+
+# Raspberry Pi Deployment
+
+KIVAI is designed to run on:
+
+- Raspberry Pi (home gateway)
+- Edge servers
+- Linux systems
+- Development machines
+
+See:
+
+```
+deploy/raspberrypi/README.md
+```
 
 ---
 
 # Current Implementation Status
 
-KIVAI currently includes:
+Implemented:
 
-- Canonical JSON Schema v1.0
-- Strict-mode runtime
-- Policy-driven authorization
-- Adapter capability contracts
-- Execution ID + audit event emission
-- Gateway reference implementation (FastAPI)
-- CLI tooling
+- Canonical Intent Schema v1.0
+- Deterministic runtime execution pipeline
+- FastAPI Gateway reference implementation
+- Adapter execution framework
+- Authorization evaluation layer
 - Deterministic ACK envelope
 
-The project operates under structured CI, semantic versioning discipline, and strict schema alignment.
+Demo‑ready:
+
+- Mock adapter support
+- Raspberry Pi gateway deployment
+- LAN execution testing
+
+Planned:
+
+- Native ESP32 adapter support
+- BLE execution path
+- Remote secure gateway mode
+- Cloud relay optional layer
 
 ---
 
-# Extending KIVAI (Adapters)
+# Integration Model
 
-KIVAI executes intents through adapters.
+KIVAI integrates with:
 
-To add a new device capability:
+- Mobile apps
+- Edge devices
+- Embedded systems
+- Local gateways
+- AI systems
 
-1. Implement an adapter with:
-   - `intent = "<intent_name>"`
-   - `execute(payload, ctx)`
-2. Declare adapter capability requirements.
-3. Register it in the adapter registry.
-
-Adapters must be deterministic and must not implement authorization logic (handled by runtime policy).
-
-See:
-
-```
-docs/device-adapter-interface.md
-```
-
----
-
-# Deployment Model
-
-v1.0 assumes a Gateway-Orchestrated Model.
-
-KIVAI can run on:
-
-- Laptop / Desktop (development)
-- Raspberry Pi / Home Hub (pilot)
-- Edge server / appliance (production)
-
-Future deployment models (embedded runtime and portable module) are documented in `docs/`.
+Voice assistants and applications interact with KIVAI by sending structured intents.
 
 ---
 
 # Licensing
 
-Licensed under the **Tech4Life Open Impact License (TOIL) v1.0**.
+Licensed under the Tech4Life Open Impact License (TOIL) v1.0.
 
-Commercial manufacturing, distribution, or commercial exploitation requires a signed TOIL Royalty Agreement with **Tech4Life & Beyond LLC**.
+Commercial manufacturing, distribution, or commercial use requires a signed TOIL Royalty Agreement with Tech4Life & Beyond LLC.
 
 Unauthorized commercial use is prohibited.
 
@@ -260,19 +251,21 @@ Unauthorized commercial use is prohibited.
 
 Maintained by:
 
-**Tech4Life & Beyond LLC**  
+Tech4Life & Beyond LLC  
 Florida, United States
 
-Part of the Tech4Life Operating System ecosystem.
+Part of the Tech4Life infrastructure ecosystem.
 
 ---
 
-# Official TOIL Product Pack
+# Product Registry Reference
 
-The canonical TOIL Product Pack for the KIVAI Platform is maintained in the Tech4Life products repository:
+Canonical product registration:
 
 https://github.com/tech4life-beyond/products/tree/main/kivai
 
-Product ID: T4L-TOIL-002-KIVAI
+Product ID:
+
+T4L-TOIL-002-KIVAI
 
 This repository contains the technical implementation layer of the KIVAI Platform.

--- a/deploy/raspberrypi/README.md
+++ b/deploy/raspberrypi/README.md
@@ -1,0 +1,159 @@
+# KIVAI Raspberry Pi Deployment (v1.0)
+
+This guide deploys the **KIVAI Gateway** on a Raspberry Pi as a **systemd service**.
+
+> Target: Raspberry Pi 3B+ (works on most Raspberry Pi models running Raspberry Pi OS).
+
+---
+
+## What you get
+
+- KIVAI Gateway running as a background service
+- Auto-start on boot
+- Health + validate + execute endpoints exposed on your LAN
+
+Default port: **8787**
+
+---
+
+## Assumptions
+
+- You cloned this repo to: `/opt/kivai`
+- You created a virtualenv at: `/opt/kivai/venv`
+- You can SSH into the Pi as user `kivai`
+
+If you haven’t done the install yet, use the quick path:
+
+```bash
+sudo mkdir -p /opt
+sudo chown -R kivai:kivai /opt
+cd /opt
+
+git clone https://github.com/tech4life-beyond/kivai.git
+cd /opt/kivai
+
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+---
+
+## 1) Install the systemd unit
+
+Copy:
+
+- `/opt/kivai/deploy/raspberrypi/systemd/kivai-gateway.service`
+
+to:
+
+- `/etc/systemd/system/kivai-gateway.service`
+
+Commands:
+
+```bash
+sudo cp /opt/kivai/deploy/raspberrypi/systemd/kivai-gateway.service /etc/systemd/system/kivai-gateway.service
+sudo systemctl daemon-reload
+```
+
+---
+
+## 2) Enable + start the service
+
+```bash
+sudo systemctl enable kivai-gateway
+sudo systemctl start kivai-gateway
+```
+
+---
+
+## 3) Verify status + view logs
+
+Status:
+
+```bash
+sudo systemctl status kivai-gateway --no-pager
+```
+
+Logs:
+
+```bash
+journalctl -u kivai-gateway -n 200 --no-pager
+```
+
+---
+
+## 4) Test from another machine on the same LAN
+
+Replace `<PI_IP>` with your Raspberry Pi’s IP.
+
+### Health
+
+```bash
+curl http://<PI_IP>:8787/health
+```
+
+Expected:
+
+```json
+{"status":"ok","service":"kivai-gateway","version":"0.1.0"}
+```
+
+### Validate (schema check)
+
+```bash
+curl -X POST http://<PI_IP>:8787/v1/validate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "intent_id":"demo-001",
+    "intent":"device.ping",
+    "target":{"device_id":"mock-001"},
+    "meta":{"timestamp":"2026-02-20T00:00:00Z","language":"en","confidence":1.0}
+  }'
+```
+
+Expected:
+
+```json
+{"ok":true,"message":"✅ Payload is valid!"}
+```
+
+### Execute (demo adapter)
+
+This will only return `status: ok` if a demo/mock adapter is registered in the runtime.
+
+```bash
+curl -X POST http://<PI_IP>:8787/v1/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "intent":"power.on",
+    "target":{"device_id":"samsung-tv-bedroom"},
+    "meta":{"timestamp":"2026-02-20T00:00:00Z","language":"en","confidence":1.0}
+  }'
+```
+
+---
+
+## Updating KIVAI on the Pi (after GitHub merges)
+
+```bash
+cd /opt/kivai
+
+git pull
+source venv/bin/activate
+pip install -r requirements.txt
+
+sudo systemctl restart kivai-gateway
+```
+
+---
+
+## Uninstall
+
+```bash
+sudo systemctl stop kivai-gateway
+sudo systemctl disable kivai-gateway
+sudo rm -f /etc/systemd/system/kivai-gateway.service
+sudo systemctl daemon-reload
+```
+

--- a/deploy/raspberrypi/systemd/kivai-gateway.service
+++ b/deploy/raspberrypi/systemd/kivai-gateway.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=KIVAI Gateway (FastAPI/Uvicorn)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=kivai
+WorkingDirectory=/opt/kivai
+Environment="PATH=/opt/kivai/venv/bin"
+ExecStart=/opt/kivai/venv/bin/python -m uvicorn kivai_sdk.gateway:app --host 0.0.0.0 --port 8787
+Restart=on-failure
+RestartSec=2
+TimeoutStartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/kivai_sdk/adapters/__init__.py
+++ b/kivai_sdk/adapters/__init__.py
@@ -1,5 +1,5 @@
 from .base import AdapterContext, KivaiAdapter
-from .registry import AdapterRegistry, default_registry
+from .registry import AdapterRegistry, default_registry, DEFAULT_REGISTRY
 from .contracts import AdapterError, AdapterResult, normalize_adapter_output
 from .capabilities import AdapterCapabilities
 
@@ -16,6 +16,7 @@ __all__ = [
     "KivaiAdapter",
     "AdapterRegistry",
     "default_registry",
+    "DEFAULT_REGISTRY",
     "AdapterError",
     "AdapterResult",
     "normalize_adapter_output",

--- a/kivai_sdk/adapters/__init__.py
+++ b/kivai_sdk/adapters/__init__.py
@@ -3,6 +3,14 @@ from .registry import AdapterRegistry, default_registry
 from .contracts import AdapterError, AdapterResult, normalize_adapter_output
 from .capabilities import AdapterCapabilities
 
+# Mock adapters (demo-ready)
+from .mock_adapter import (
+    MockDevicePingAdapter,
+    MockPowerOnAdapter,
+    MockPowerOffAdapter,
+    MockFindBeepAdapter,
+)
+
 __all__ = [
     "AdapterContext",
     "KivaiAdapter",
@@ -12,4 +20,9 @@ __all__ = [
     "AdapterResult",
     "normalize_adapter_output",
     "AdapterCapabilities",
+    # Mock adapters
+    "MockDevicePingAdapter",
+    "MockPowerOnAdapter",
+    "MockPowerOffAdapter",
+    "MockFindBeepAdapter",
 ]

--- a/kivai_sdk/adapters/builtin/lock.py
+++ b/kivai_sdk/adapters/builtin/lock.py
@@ -23,7 +23,7 @@ class UnlockDoorAdapter:
         # Locks are sensitive; require auth baseline.
         return AdapterCapabilities(
             intent=self.intent,
-            required_capabilities=["lock_control"],
+            required_capabilities=frozenset({"lock_control"}),
             requires_auth=True,
             required_role="owner",
         )

--- a/kivai_sdk/adapters/builtin/lock.py
+++ b/kivai_sdk/adapters/builtin/lock.py
@@ -5,41 +5,32 @@ from kivai_sdk.adapters.capabilities import AdapterCapabilities
 
 
 class UnlockDoorAdapter:
-    """
-    Built-in reference adapter (demo-grade).
-    Intent: unlock_door
-
-    NOTE:
-    - This is NOT a real lock integration.
-    - It only returns a deterministic result for demos/tests.
-    """
-
     @property
     def intent(self) -> str:
         return "unlock_door"
 
     @property
     def capabilities(self) -> AdapterCapabilities:
-        # Locks are sensitive; require auth baseline.
         return AdapterCapabilities(
-            intent=self.intent,
+            intent="unlock_door",
             required_capabilities=frozenset({"lock_control"}),
             requires_auth=True,
             required_role="owner",
         )
 
     def execute(self, payload: dict, ctx: AdapterContext) -> dict:
+
         target = payload.get("target") or {}
         device_id = target.get("device_id") or "unknown-device"
+
         return {
             "ok": True,
             "adapter": "builtin",
-            "intent": self.intent,
+            "intent": "unlock_door",
             "device_id": device_id,
             "state": "unlocked",
+            "gateway_id": ctx.gateway_id,
         }
 
 
-# Backwards-compatible alias:
-# Some older docs/branches may refer to DoorLockAdapter.
 DoorLockAdapter = UnlockDoorAdapter

--- a/kivai_sdk/adapters/builtin/lock.py
+++ b/kivai_sdk/adapters/builtin/lock.py
@@ -6,28 +6,40 @@ from kivai_sdk.adapters.capabilities import AdapterCapabilities
 
 class UnlockDoorAdapter:
     """
-    Reference adapter: unlock_door
+    Built-in reference adapter (demo-grade).
+    Intent: unlock_door
 
-    v0.9 strict:
-    - adapter declares auth baseline (owner)
-    - runtime enforces auth deterministically
+    NOTE:
+    - This is NOT a real lock integration.
+    - It only returns a deterministic result for demos/tests.
     """
 
-    intent = "unlock_door"
+    @property
+    def intent(self) -> str:
+        return "unlock_door"
 
     @property
     def capabilities(self) -> AdapterCapabilities:
+        # Locks are sensitive; require auth baseline.
         return AdapterCapabilities(
-            intent="unlock_door",
-            required_capabilities=frozenset({"lock"}),
+            intent=self.intent,
+            required_capabilities=["lock_control"],
             requires_auth=True,
             required_role="owner",
-            timeout_ms=5000,
         )
 
     def execute(self, payload: dict, ctx: AdapterContext) -> dict:
+        target = payload.get("target") or {}
+        device_id = target.get("device_id") or "unknown-device"
         return {
             "ok": True,
-            "action": "unlock_door",
-            "gateway_id": ctx.gateway_id,
+            "adapter": "builtin",
+            "intent": self.intent,
+            "device_id": device_id,
+            "state": "unlocked",
         }
+
+
+# Backwards-compatible alias:
+# Some older docs/branches may refer to DoorLockAdapter.
+DoorLockAdapter = UnlockDoorAdapter

--- a/kivai_sdk/adapters/mock_adapter.py
+++ b/kivai_sdk/adapters/mock_adapter.py
@@ -4,6 +4,34 @@ from kivai_sdk.adapters.base import AdapterContext
 from kivai_sdk.adapters.capabilities import AdapterCapabilities
 
 
+# REQUIRED by tests and CLI
+class EchoAdapter:
+    @property
+    def intent(self) -> str:
+        return "echo"
+
+    @property
+    def capabilities(self) -> AdapterCapabilities:
+        return AdapterCapabilities(
+            intent="echo",
+            required_capabilities=frozenset(),
+            requires_auth=False,
+            required_role=None,
+        )
+
+    def execute(self, payload: dict, ctx: AdapterContext) -> dict:
+        params = payload.get("params") or {}
+        message = params.get("message")
+
+        return {
+            "ok": True,
+            "adapter": "mock",
+            "intent": "echo",
+            "message": message,
+            "gateway_id": ctx.gateway_id,
+        }
+
+
 class MockDevicePingAdapter:
     @property
     def intent(self) -> str:
@@ -12,8 +40,8 @@ class MockDevicePingAdapter:
     @property
     def capabilities(self) -> AdapterCapabilities:
         return AdapterCapabilities(
-            intent=self.intent,
-            required_capabilities=[],
+            intent="device.ping",
+            required_capabilities=frozenset(),
             requires_auth=False,
             required_role=None,
         )
@@ -21,10 +49,11 @@ class MockDevicePingAdapter:
     def execute(self, payload: dict, ctx: AdapterContext) -> dict:
         target = payload.get("target") or {}
         device_id = target.get("device_id") or "unknown-device"
+
         return {
             "ok": True,
             "adapter": "mock",
-            "intent": self.intent,
+            "intent": "device.ping",
             "device_id": device_id,
             "pong": True,
         }
@@ -38,8 +67,8 @@ class MockPowerOnAdapter:
     @property
     def capabilities(self) -> AdapterCapabilities:
         return AdapterCapabilities(
-            intent=self.intent,
-            required_capabilities=[],
+            intent="power.on",
+            required_capabilities=frozenset(),
             requires_auth=False,
             required_role=None,
         )
@@ -47,10 +76,11 @@ class MockPowerOnAdapter:
     def execute(self, payload: dict, ctx: AdapterContext) -> dict:
         target = payload.get("target") or {}
         device_id = target.get("device_id") or "unknown-device"
+
         return {
             "ok": True,
             "adapter": "mock",
-            "intent": self.intent,
+            "intent": "power.on",
             "device_id": device_id,
             "state": "on",
         }
@@ -64,8 +94,8 @@ class MockPowerOffAdapter:
     @property
     def capabilities(self) -> AdapterCapabilities:
         return AdapterCapabilities(
-            intent=self.intent,
-            required_capabilities=[],
+            intent="power.off",
+            required_capabilities=frozenset(),
             requires_auth=False,
             required_role=None,
         )
@@ -73,10 +103,11 @@ class MockPowerOffAdapter:
     def execute(self, payload: dict, ctx: AdapterContext) -> dict:
         target = payload.get("target") or {}
         device_id = target.get("device_id") or "unknown-device"
+
         return {
             "ok": True,
             "adapter": "mock",
-            "intent": self.intent,
+            "intent": "power.off",
             "device_id": device_id,
             "state": "off",
         }
@@ -90,8 +121,8 @@ class MockFindBeepAdapter:
     @property
     def capabilities(self) -> AdapterCapabilities:
         return AdapterCapabilities(
-            intent=self.intent,
-            required_capabilities=[],
+            intent="find.beep",
+            required_capabilities=frozenset(),
             requires_auth=False,
             required_role=None,
         )
@@ -99,12 +130,14 @@ class MockFindBeepAdapter:
     def execute(self, payload: dict, ctx: AdapterContext) -> dict:
         target = payload.get("target") or {}
         params = payload.get("params") or {}
+
         device_id = target.get("device_id") or "unknown-device"
         duration_ms = params.get("duration_ms", 1500)
+
         return {
             "ok": True,
             "adapter": "mock",
-            "intent": self.intent,
+            "intent": "find.beep",
             "device_id": device_id,
             "action": "beep",
             "duration_ms": duration_ms,

--- a/kivai_sdk/adapters/mock_adapter.py
+++ b/kivai_sdk/adapters/mock_adapter.py
@@ -23,12 +23,10 @@ class EchoAdapter:
         params = payload.get("params") or {}
         message = params.get("message")
 
+        # CRITICAL: tests expect key "echo"
         return {
             "ok": True,
-            "adapter": "mock",
-            "intent": "echo",
-            "message": message,
-            "gateway_id": ctx.gateway_id,
+            "echo": message,
         }
 
 

--- a/kivai_sdk/adapters/mock_adapter.py
+++ b/kivai_sdk/adapters/mock_adapter.py
@@ -4,7 +4,6 @@ from kivai_sdk.adapters.base import AdapterContext
 from kivai_sdk.adapters.capabilities import AdapterCapabilities
 
 
-# REQUIRED by tests and CLI
 class EchoAdapter:
     @property
     def intent(self) -> str:
@@ -23,10 +22,10 @@ class EchoAdapter:
         params = payload.get("params") or {}
         message = params.get("message")
 
-        # CRITICAL: tests expect key "echo"
         return {
             "ok": True,
             "echo": message,
+            "gateway_id": ctx.gateway_id,  # REQUIRED BY TEST
         }
 
 

--- a/kivai_sdk/adapters/mock_adapter.py
+++ b/kivai_sdk/adapters/mock_adapter.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from kivai_sdk.adapters.base import AdapterContext
+from kivai_sdk.adapters.capabilities import AdapterCapabilities
+
+
+class MockDevicePingAdapter:
+    @property
+    def intent(self) -> str:
+        return "device.ping"
+
+    @property
+    def capabilities(self) -> AdapterCapabilities:
+        return AdapterCapabilities(
+            intent=self.intent,
+            required_capabilities=[],
+            requires_auth=False,
+            required_role=None,
+        )
+
+    def execute(self, payload: dict, ctx: AdapterContext) -> dict:
+        target = payload.get("target") or {}
+        device_id = target.get("device_id") or "unknown-device"
+        return {
+            "ok": True,
+            "adapter": "mock",
+            "intent": self.intent,
+            "device_id": device_id,
+            "pong": True,
+        }
+
+
+class MockPowerOnAdapter:
+    @property
+    def intent(self) -> str:
+        return "power.on"
+
+    @property
+    def capabilities(self) -> AdapterCapabilities:
+        return AdapterCapabilities(
+            intent=self.intent,
+            required_capabilities=[],
+            requires_auth=False,
+            required_role=None,
+        )
+
+    def execute(self, payload: dict, ctx: AdapterContext) -> dict:
+        target = payload.get("target") or {}
+        device_id = target.get("device_id") or "unknown-device"
+        return {
+            "ok": True,
+            "adapter": "mock",
+            "intent": self.intent,
+            "device_id": device_id,
+            "state": "on",
+        }
+
+
+class MockPowerOffAdapter:
+    @property
+    def intent(self) -> str:
+        return "power.off"
+
+    @property
+    def capabilities(self) -> AdapterCapabilities:
+        return AdapterCapabilities(
+            intent=self.intent,
+            required_capabilities=[],
+            requires_auth=False,
+            required_role=None,
+        )
+
+    def execute(self, payload: dict, ctx: AdapterContext) -> dict:
+        target = payload.get("target") or {}
+        device_id = target.get("device_id") or "unknown-device"
+        return {
+            "ok": True,
+            "adapter": "mock",
+            "intent": self.intent,
+            "device_id": device_id,
+            "state": "off",
+        }
+
+
+class MockFindBeepAdapter:
+    @property
+    def intent(self) -> str:
+        return "find.beep"
+
+    @property
+    def capabilities(self) -> AdapterCapabilities:
+        return AdapterCapabilities(
+            intent=self.intent,
+            required_capabilities=[],
+            requires_auth=False,
+            required_role=None,
+        )
+
+    def execute(self, payload: dict, ctx: AdapterContext) -> dict:
+        target = payload.get("target") or {}
+        params = payload.get("params") or {}
+        device_id = target.get("device_id") or "unknown-device"
+        duration_ms = params.get("duration_ms", 1500)
+        return {
+            "ok": True,
+            "adapter": "mock",
+            "intent": self.intent,
+            "device_id": device_id,
+            "action": "beep",
+            "duration_ms": duration_ms,
+        }

--- a/kivai_sdk/adapters/registry.py
+++ b/kivai_sdk/adapters/registry.py
@@ -9,29 +9,18 @@ from kivai_sdk.adapters.builtin.lock import UnlockDoorAdapter
 from kivai_sdk.adapters.builtin.speaker import PlayMusicAdapter
 from kivai_sdk.adapters.builtin.thermostat import SetTemperatureAdapter
 
-# Mock adapters (demo-ready)
+# Mock adapters
 from kivai_sdk.adapters.mock_adapter import (
+    EchoAdapter,
     MockDevicePingAdapter,
-    MockFindBeepAdapter,
-    MockPowerOffAdapter,
     MockPowerOnAdapter,
+    MockPowerOffAdapter,
+    MockFindBeepAdapter,
 )
 
 
 class AdapterRegistry:
-    """
-    In-memory adapter registry.
-
-    Provides:
-    - register(adapter)
-    - resolve(intent)
-    - list_intents()
-
-    Compatible with runtime, CLI, and tests.
-    """
-
     def __init__(self) -> None:
-        # CLI expects this exact name
         self._by_intent: Dict[str, object] = {}
 
     def register(self, adapter: object) -> None:
@@ -46,17 +35,11 @@ class AdapterRegistry:
         self._by_intent[intent] = adapter
 
     def resolve(self, intent: Optional[str]) -> Optional[object]:
-        """
-        Resolve adapter by intent.
-
-        Required by runtime and tests.
-        """
         if not intent or not isinstance(intent, str):
             return None
 
         return self._by_intent.get(intent)
 
-    # Backwards compatibility
     def get(self, intent: str) -> Optional[object]:
         return self.resolve(intent)
 
@@ -67,10 +50,13 @@ class AdapterRegistry:
 def _build_default_registry() -> AdapterRegistry:
     reg = AdapterRegistry()
 
-    # Built-in adapters
+    # Builtins
     reg.register(SetTemperatureAdapter())
     reg.register(PlayMusicAdapter())
     reg.register(UnlockDoorAdapter())
+
+    # REQUIRED by tests
+    reg.register(EchoAdapter())
 
     # Mock adapters
     reg.register(MockDevicePingAdapter())
@@ -82,14 +68,9 @@ def _build_default_registry() -> AdapterRegistry:
 
 
 def default_registry() -> AdapterRegistry:
-    """
-    Factory function used by runtime/tests.
-    Must return fresh instance.
-    """
     return _build_default_registry()
 
 
-# Singleton instance for CLI / non-test paths
 DEFAULT_REGISTRY = _build_default_registry()
 
 

--- a/kivai_sdk/adapters/registry.py
+++ b/kivai_sdk/adapters/registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
 
 from kivai_sdk.adapters.base import AdapterContext
 
@@ -21,38 +21,58 @@ from kivai_sdk.adapters.mock_adapter import (
 class AdapterRegistry:
     """
     In-memory adapter registry.
+
+    Provides:
+    - register(adapter)
+    - resolve(intent)
+    - list_intents()
+
+    Compatible with runtime, CLI, and tests.
     """
 
     def __init__(self) -> None:
-        self._adapters: Dict[str, object] = {}
+        # CLI expects this exact name
+        self._by_intent: Dict[str, object] = {}
 
     def register(self, adapter: object) -> None:
         intent = getattr(adapter, "intent", None)
+
         if callable(intent):
             intent = intent()
+
         if not isinstance(intent, str) or not intent.strip():
             raise ValueError("Adapter must define a non-empty .intent")
-        self._adapters[intent] = adapter
 
-    def get(self, intent: str) -> object | None:
-        return self._adapters.get(intent)
+        self._by_intent[intent] = adapter
+
+    def resolve(self, intent: Optional[str]) -> Optional[object]:
+        """
+        Resolve adapter by intent.
+
+        Required by runtime and tests.
+        """
+        if not intent or not isinstance(intent, str):
+            return None
+
+        return self._by_intent.get(intent)
+
+    # Backwards compatibility
+    def get(self, intent: str) -> Optional[object]:
+        return self.resolve(intent)
 
     def list_intents(self) -> list[str]:
-        return sorted(self._adapters.keys())
+        return sorted(self._by_intent.keys())
 
 
 def _build_default_registry() -> AdapterRegistry:
-    """
-    Build a fresh registry instance (tests expect default_registry() callable).
-    """
     reg = AdapterRegistry()
 
-    # Built-in reference adapters
+    # Built-in adapters
     reg.register(SetTemperatureAdapter())
     reg.register(PlayMusicAdapter())
     reg.register(UnlockDoorAdapter())
 
-    # Demo/mock intents so /v1/execute is exciting immediately
+    # Mock adapters
     reg.register(MockDevicePingAdapter())
     reg.register(MockPowerOnAdapter())
     reg.register(MockPowerOffAdapter())
@@ -63,13 +83,19 @@ def _build_default_registry() -> AdapterRegistry:
 
 def default_registry() -> AdapterRegistry:
     """
-    Backwards-compatible factory (callable) used across tests/runtime.
-    Returns a registry pre-loaded with builtin + mock adapters.
+    Factory function used by runtime/tests.
+    Must return fresh instance.
     """
     return _build_default_registry()
 
 
-# Optional: a single prebuilt instance for non-test code paths.
+# Singleton instance for CLI / non-test paths
 DEFAULT_REGISTRY = _build_default_registry()
 
-__all__ = ["AdapterRegistry", "AdapterContext", "default_registry", "DEFAULT_REGISTRY"]
+
+__all__ = [
+    "AdapterRegistry",
+    "AdapterContext",
+    "default_registry",
+    "DEFAULT_REGISTRY",
+]

--- a/kivai_sdk/adapters/registry.py
+++ b/kivai_sdk/adapters/registry.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Dict
 
 from kivai_sdk.adapters.base import AdapterContext
+
+# Builtins
 from kivai_sdk.adapters.builtin.lock import UnlockDoorAdapter
 from kivai_sdk.adapters.builtin.speaker import PlayMusicAdapter
 from kivai_sdk.adapters.builtin.thermostat import SetTemperatureAdapter
@@ -39,17 +41,35 @@ class AdapterRegistry:
         return sorted(self._adapters.keys())
 
 
-# Default registry used by the runtime (demo + builtin)
-default_registry = AdapterRegistry()
-default_registry.register(SetTemperatureAdapter())
-default_registry.register(PlayMusicAdapter())
-default_registry.register(UnlockDoorAdapter())
+def _build_default_registry() -> AdapterRegistry:
+    """
+    Build a fresh registry instance (tests expect default_registry() callable).
+    """
+    reg = AdapterRegistry()
 
-# Demo/mock intents so /v1/execute is exciting immediately
-default_registry.register(MockDevicePingAdapter())
-default_registry.register(MockPowerOnAdapter())
-default_registry.register(MockPowerOffAdapter())
-default_registry.register(MockFindBeepAdapter())
+    # Built-in reference adapters
+    reg.register(SetTemperatureAdapter())
+    reg.register(PlayMusicAdapter())
+    reg.register(UnlockDoorAdapter())
+
+    # Demo/mock intents so /v1/execute is exciting immediately
+    reg.register(MockDevicePingAdapter())
+    reg.register(MockPowerOnAdapter())
+    reg.register(MockPowerOffAdapter())
+    reg.register(MockFindBeepAdapter())
+
+    return reg
 
 
-__all__ = ["AdapterRegistry", "AdapterContext", "default_registry"]
+def default_registry() -> AdapterRegistry:
+    """
+    Backwards-compatible factory (callable) used across tests/runtime.
+    Returns a registry pre-loaded with builtin + mock adapters.
+    """
+    return _build_default_registry()
+
+
+# Optional: a single prebuilt instance for non-test code paths.
+DEFAULT_REGISTRY = _build_default_registry()
+
+__all__ = ["AdapterRegistry", "AdapterContext", "default_registry", "DEFAULT_REGISTRY"]

--- a/kivai_sdk/adapters/registry.py
+++ b/kivai_sdk/adapters/registry.py
@@ -1,75 +1,66 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable
+from typing import Optional
 
-from kivai_sdk.adapters.builtin import (
-    PlayMusicAdapter,
-    SetTemperatureAdapter,
-    UnlockDoorAdapter,
+from kivai_sdk.adapters.base import KivaiAdapter
+
+# Built-in reference adapters
+from kivai_sdk.adapters.builtin.lock import DoorLockAdapter
+from kivai_sdk.adapters.builtin.speaker import PlayMusicAdapter
+from kivai_sdk.adapters.builtin.thermostat import SetTemperatureAdapter
+from kivai_sdk.adapters.builtin.vision import DetectObjectsAdapter
+
+# Demo/mock adapters (software-only)
+from kivai_sdk.adapters.mock_adapter import (
+    MockDevicePingAdapter,
+    MockPowerOnAdapter,
+    MockPowerOffAdapter,
+    MockFindBeepAdapter,
 )
-
-from .base import AdapterContext, KivaiAdapter
-from .capabilities import AdapterCapabilities
 
 
 @dataclass
+class AdapterRegistration:
+    intent: str
+    adapter: KivaiAdapter
+
+
 class AdapterRegistry:
     """
-    Simple in-process registry.
-
-    Future: dynamic discovery, versioning, capability matching, remote adapters.
+    Registry maps `intent` -> adapter that can execute that intent.
     """
 
-    _by_intent: Dict[str, KivaiAdapter]
-
-    @classmethod
-    def empty(cls) -> "AdapterRegistry":
-        return cls(_by_intent={})
+    def __init__(self) -> None:
+        self._adapters: dict[str, AdapterRegistration] = {}
 
     def register(self, adapter: KivaiAdapter) -> None:
-        self._by_intent[adapter.intent] = adapter
+        intent = getattr(adapter, "intent", None)
+        if not isinstance(intent, str) or not intent.strip():
+            raise ValueError("Adapter must define non-empty .intent string")
+        self._adapters[intent] = AdapterRegistration(intent=intent, adapter=adapter)
 
-    def register_many(self, adapters: Iterable[KivaiAdapter]) -> None:
-        for a in adapters:
-            self.register(a)
-
-    def resolve(self, intent: str | None) -> KivaiAdapter | None:
+    def resolve(self, intent: str | None) -> Optional[KivaiAdapter]:
         if not intent:
             return None
-        return self._by_intent.get(intent)
+        reg = self._adapters.get(intent)
+        return reg.adapter if reg else None
+
+    def list_intents(self) -> list[str]:
+        return sorted(self._adapters.keys())
 
 
-class EchoAdapter:
-    """
-    Reference adapter: echo (local, deterministic).
-    Kept outside schema by design, but still must declare capabilities in v0.9 strict.
-    """
+# Canonical default registry (ships with built-ins + demo mocks)
+default_registry = AdapterRegistry()
 
-    intent = "echo"
+# Built-ins (examples)
+default_registry.register(DoorLockAdapter())
+default_registry.register(PlayMusicAdapter())
+default_registry.register(SetTemperatureAdapter())
+default_registry.register(DetectObjectsAdapter())
 
-    @property
-    def capabilities(self) -> AdapterCapabilities:
-        return AdapterCapabilities(
-            intent="echo",
-            required_capabilities=frozenset(),
-            requires_auth=False,
-            required_role=None,
-            timeout_ms=1000,
-        )
-
-    def execute(self, payload: dict, ctx: AdapterContext) -> dict:
-        params = (
-            payload.get("params") if isinstance(payload.get("params"), dict) else {}
-        )
-        msg = params.get("message", "")
-        return {"echo": msg, "gateway_id": ctx.gateway_id}
-
-
-def default_registry() -> AdapterRegistry:
-    reg = AdapterRegistry.empty()
-    reg.register(EchoAdapter())
-    reg.register(SetTemperatureAdapter())
-    reg.register(PlayMusicAdapter())
-    reg.register(UnlockDoorAdapter())
-    return reg
+# Mocks (demo-ready immediately)
+default_registry.register(MockDevicePingAdapter())
+default_registry.register(MockPowerOnAdapter())
+default_registry.register(MockPowerOffAdapter())
+default_registry.register(MockFindBeepAdapter())

--- a/kivai_sdk/adapters/registry.py
+++ b/kivai_sdk/adapters/registry.py
@@ -1,66 +1,55 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
+from typing import Dict
 
-from kivai_sdk.adapters.base import KivaiAdapter
-
-# Built-in reference adapters
-from kivai_sdk.adapters.builtin.lock import DoorLockAdapter
+from kivai_sdk.adapters.base import AdapterContext
+from kivai_sdk.adapters.builtin.lock import UnlockDoorAdapter
 from kivai_sdk.adapters.builtin.speaker import PlayMusicAdapter
 from kivai_sdk.adapters.builtin.thermostat import SetTemperatureAdapter
-from kivai_sdk.adapters.builtin.vision import DetectObjectsAdapter
 
-# Demo/mock adapters (software-only)
+# Mock adapters (demo-ready)
 from kivai_sdk.adapters.mock_adapter import (
     MockDevicePingAdapter,
-    MockPowerOnAdapter,
-    MockPowerOffAdapter,
     MockFindBeepAdapter,
+    MockPowerOffAdapter,
+    MockPowerOnAdapter,
 )
-
-
-@dataclass
-class AdapterRegistration:
-    intent: str
-    adapter: KivaiAdapter
 
 
 class AdapterRegistry:
     """
-    Registry maps `intent` -> adapter that can execute that intent.
+    In-memory adapter registry.
     """
 
     def __init__(self) -> None:
-        self._adapters: dict[str, AdapterRegistration] = {}
+        self._adapters: Dict[str, object] = {}
 
-    def register(self, adapter: KivaiAdapter) -> None:
+    def register(self, adapter: object) -> None:
         intent = getattr(adapter, "intent", None)
+        if callable(intent):
+            intent = intent()
         if not isinstance(intent, str) or not intent.strip():
-            raise ValueError("Adapter must define non-empty .intent string")
-        self._adapters[intent] = AdapterRegistration(intent=intent, adapter=adapter)
+            raise ValueError("Adapter must define a non-empty .intent")
+        self._adapters[intent] = adapter
 
-    def resolve(self, intent: str | None) -> Optional[KivaiAdapter]:
-        if not intent:
-            return None
-        reg = self._adapters.get(intent)
-        return reg.adapter if reg else None
+    def get(self, intent: str) -> object | None:
+        return self._adapters.get(intent)
 
     def list_intents(self) -> list[str]:
         return sorted(self._adapters.keys())
 
 
-# Canonical default registry (ships with built-ins + demo mocks)
+# Default registry used by the runtime (demo + builtin)
 default_registry = AdapterRegistry()
-
-# Built-ins (examples)
-default_registry.register(DoorLockAdapter())
-default_registry.register(PlayMusicAdapter())
 default_registry.register(SetTemperatureAdapter())
-default_registry.register(DetectObjectsAdapter())
+default_registry.register(PlayMusicAdapter())
+default_registry.register(UnlockDoorAdapter())
 
-# Mocks (demo-ready immediately)
+# Demo/mock intents so /v1/execute is exciting immediately
 default_registry.register(MockDevicePingAdapter())
 default_registry.register(MockPowerOnAdapter())
 default_registry.register(MockPowerOffAdapter())
 default_registry.register(MockFindBeepAdapter())
+
+
+__all__ = ["AdapterRegistry", "AdapterContext", "default_registry"]

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,24 @@ from setuptools import setup, find_packages
 
 setup(
     name="kivai_sdk",
-    version="0.1.3",
-    description="SDK for validating Kivai protocol commands",
+    version="0.1.4",
+    description="KIVAI SDK + reference gateway for validating and executing KIVAI intents",
     author="Tech4Life & Beyond LLC",
     license="Tech4Life Open Impact License (TOIL) v1.0",
     packages=find_packages(),
     package_data={
-        "kivai_sdk": ["schema/kivai-command.schema.json"],
+        # Packaged schema (fixes previous broken path)
+        "kivai_sdk": ["schema/*.json"],
     },
-    install_requires=["jsonschema"],
+    install_requires=[
+        "jsonschema",
+    ],
     entry_points={
         "console_scripts": [
             "kivai=kivai_sdk.cli:main",
         ],
     },
-    keywords=["kivai", "validator", "jsonschema", "iot", "commands"],
+    keywords=["kivai", "intent", "validator", "jsonschema", "iot", "gateway"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Other/Proprietary License",


### PR DESCRIPTION
…stemd + docker compose

Fix setup.py to package the correct schema file (kivai-intent-v1.schema.json) and remove stale schema path.

Add a mock adapter with minimal demo intents (device.ping, power.on/off, find.beep) so /v1/execute works without hardware.

Add deploy/raspberrypi/systemd/kivai-gateway.service for persistent gateway operation.

Add optional docker-compose.yml for easy local bring-up.

Update README to reflect v1 demo workflow and release discipline (no false claims).

Normalize line endings (CRLF→LF) for reproducibility.

## Summary
What does this PR change?

## Type
- [ ] Schema / Spec
- [ ] Validator / Runtime
- [ ] Gateway / Adapters
- [ ] Tests
- [ ] CI / Workflows
- [ ] Docs

## Checklist
- [ ] Actions pinned by SHA (if workflow changes)
- [ ] Tests updated/added (if behavior changes)
- [ ] Schema changes are backwards-compatible or clearly versioned
- [ ] No confidential/internal-only content added
