### PR TITLE
Fix schema packaging so pip installs include KIVAI schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ venv/
 dist/
 build/
 *.egg-info/
+
+.tmp/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,7 @@
-include kivai_sdk/schema/kivai-command.schema.json
+include LICENSE
+include README.md
+include CHANGELOG.md
+include requirements.txt
+
+recursive-include kivai_sdk/schema *.json
+recursive-include kivai_sdk/schema/legacy *.json

--- a/kivai_sdk/schema/kivai-intent-v1.schema.json
+++ b/kivai_sdk/schema/kivai-intent-v1.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/tech4life-beyond/kivai/blob/main/schema/kivai-intent-v1.schema.json",
+  "title": "KivaiIntentV1",
+  "description": "Kivai v1.0 canonical intent payload schema (gateway/hub orchestrated).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["intent_id", "intent", "target", "meta"],
+  "properties": {
+    "intent_id": {
+      "type": "string",
+      "description": "Unique identifier for the intent (used for tracking and correlation).",
+      "minLength": 8
+    },
+    "intent": {
+      "type": "string",
+      "description": "Canonical action identifier (e.g., close, lock, set_temperature, locate).",
+      "minLength": 1
+    },
+    "target": {
+      "type": "object",
+      "description": "Defines routing and selection of the execution endpoint.",
+      "additionalProperties": false,
+      "properties": {
+        "device_id": {
+          "type": "string",
+          "description": "Direct identifier for a specific device endpoint.",
+          "minLength": 1
+        },
+        "capability": {
+          "type": "string",
+          "description": "Capability category used for capability+zone targeting (fallback).",
+          "minLength": 1
+        },
+        "zone": {
+          "type": "string",
+          "description": "Zone/location used for capability+zone targeting (fallback).",
+          "minLength": 1
+        }
+      },
+      "anyOf": [
+        { "required": ["device_id"] },
+        { "required": ["capability", "zone"] }
+      ]
+    },
+    "params": {
+      "type": "object",
+      "description": "Intent-specific parameters.",
+      "additionalProperties": true
+    },
+    "auth": {
+      "type": "object",
+      "description": "Authorization proof and required role. Required for sensitive intents.",
+      "additionalProperties": false,
+      "required": ["required_role", "token"],
+      "properties": {
+        "required_role": {
+          "type": "string",
+          "description": "Role required to authorize execution (e.g., owner).",
+          "minLength": 1
+        },
+        "token": {
+          "type": "string",
+          "description": "Signed session token or equivalent authorization proof.",
+          "minLength": 1
+        }
+      }
+    },
+    "meta": {
+      "type": "object",
+      "description": "Metadata for observability and auditing.",
+      "additionalProperties": false,
+      "required": ["timestamp", "language", "confidence"],
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when the intent was created."
+        },
+        "language": {
+          "type": "string",
+          "description": "Language of the original user input (e.g., en, es).",
+          "minLength": 2
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Confidence score from the intent generation layer (0..1)."
+        },
+        "source": {
+          "type": "string",
+          "description": "Origin of the intent (e.g., gateway, assistant)."
+        },
+        "trigger": {
+          "type": "string",
+          "description": "Optional trigger word used by voice parsing layers (e.g., Kivai)."
+        },
+        "user_id": {
+          "type": "string",
+          "description": "Optional privacy-sensitive user identifier."
+        }
+      }
+    }
+  }
+}

--- a/kivai_sdk/schema/legacy/kivai-command.schema.json
+++ b/kivai_sdk/schema/legacy/kivai-command.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "KivaiCommand",
+  "type": "object",
+  "required": ["command", "object", "trigger"],
+  "properties": {
+    "command": {
+      "type": "string",
+      "description": "Legacy command verb."
+    },
+    "object": {
+      "type": "string",
+      "description": "Legacy target object name."
+    },
+    "trigger": {
+      "type": "string",
+      "description": "Legacy trigger type (e.g., voice, schedule)."
+    },
+    "params": {
+      "type": "object",
+      "description": "Legacy parameters for the command.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/kivai_sdk/validator.py
+++ b/kivai_sdk/validator.py
@@ -1,14 +1,22 @@
+from __future__ import annotations
+
 import json
 import os
-from jsonschema import validate, ValidationError
+from typing import Any
+
+from jsonschema import ValidationError, validate
+
+try:
+    # Python 3.9+
+    from importlib import resources as importlib_resources
+except Exception:  # pragma: no cover
+    importlib_resources = None  # type: ignore
 
 
-def _default_v1_schema_path() -> str:
+def _repo_root_schema_path() -> str:
     """
-    Resolve the canonical v1 schema path from inside the package.
-
     Repo layout:
-      - schema/kivai-intent-v1.schema.json      (canonical)
+      - schema/kivai-intent-v1.schema.json      (canonical in-repo location)
       - kivai_sdk/validator.py                  (this file)
 
     From kivai_sdk/ -> go up 1 level to repo root, then /schema/...
@@ -17,7 +25,32 @@ def _default_v1_schema_path() -> str:
     return os.path.join(repo_root, "schema", "kivai-intent-v1.schema.json")
 
 
-def load_schema(schema_path: str | None = None) -> dict:
+def _package_schema_path() -> str | None:
+    """
+    Installed package layout:
+      - kivai_sdk/schema/kivai-intent-v1.schema.json
+
+    Returns a filesystem path when possible; otherwise None.
+    """
+    if importlib_resources is None:
+        return None
+
+    try:
+        p = importlib_resources.files("kivai_sdk").joinpath(
+            "schema/kivai-intent-v1.schema.json"
+        )
+        with importlib_resources.as_file(p) as local_path:
+            return str(local_path)
+    except Exception:
+        return None
+
+
+def _default_v1_schema_path() -> str:
+    # Prefer packaged schema (pip install safe). Fallback to repo-root schema.
+    return _package_schema_path() or _repo_root_schema_path()
+
+
+def load_schema(schema_path: str | None = None) -> dict[str, Any]:
     if schema_path is None:
         schema_path = _default_v1_schema_path()
 
@@ -25,11 +58,15 @@ def load_schema(schema_path: str | None = None) -> dict:
         return json.load(file)
 
 
-def validate_command(payload: dict, schema_path: str | None = None) -> tuple[bool, str]:
+def validate_command(
+    payload: dict[str, Any], schema_path: str | None = None
+) -> tuple[bool, str]:
     """
     Validates a payload against the Kivai JSON Schema.
 
-    Default: Kivai Intent v1 (schema/kivai-intent-v1.schema.json)
+    Default: Kivai Intent v1.
+      - Packaged install: kivai_sdk/schema/kivai-intent-v1.schema.json
+      - Repo fallback: schema/kivai-intent-v1.schema.json
 
     Legacy schemas can still be validated by passing schema_path explicitly.
     """

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,17 @@ from setuptools import setup, find_packages
 
 setup(
     name="kivai_sdk",
-    version="0.1.3",
-    description="SDK for validating Kivai protocol commands",
+    version="0.1.4",
+    description="SDK for validating Kivai intents (schema-driven)",
     author="Tech4Life & Beyond LLC",
     license="Tech4Life Open Impact License (TOIL) v1.0",
     packages=find_packages(),
     package_data={
-        "kivai_sdk": ["schema/kivai-command.schema.json"],
+        # Ship schemas inside the Python package so pip installs are self-contained.
+        "kivai_sdk": [
+            "schema/*.json",
+            "schema/legacy/*.json",
+        ],
     },
     install_requires=["jsonschema"],
     entry_points={
@@ -16,7 +20,7 @@ setup(
             "kivai=kivai_sdk.cli:main",
         ],
     },
-    keywords=["kivai", "validator", "jsonschema", "iot", "commands"],
+    keywords=["kivai", "validator", "jsonschema", "iot", "intents", "interoperability"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Other/Proprietary License",


### PR DESCRIPTION
- Include v1 + legacy schemas inside kivai_sdk package for deterministic runtime installs
- Fix setup.py package_data path (previously pointed to non-existent location)
- Update MANIFEST.in to include packaged schema JSON files
- Update validator to load packaged schema first, with repo fallback
- Remove temporary directory and add .tmp/ to .gitignore

## Summary
What does this PR change?

## Type
- [ ] Schema / Spec
- [ ] Validator / Runtime
- [ ] Gateway / Adapters
- [ ] Tests
- [ ] CI / Workflows
- [ ] Docs

## Checklist
- [ ] Actions pinned by SHA (if workflow changes)
- [ ] Tests updated/added (if behavior changes)
- [ ] Schema changes are backwards-compatible or clearly versioned
- [ ] No confidential/internal-only content added
